### PR TITLE
fix(cache): Correctly invalidate expense data cache

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -29,6 +29,7 @@ function onOpen() {
       .addItem('Setup Location Mapping Sheet', 'setupLocationMappingMenu') // Wrapper  
       .addItem('Setup All Expense Sheets', 'setupAllExpenseSheetsMenu') // Wrapper
       .addSeparator()
+      .addItem('Cleanup Legacy Cache', 'cleanupLegacyCacheMenu') // Wrapper
       // .addItem('Update Form From Points Reference', 'updateFormMenu') // Obsolete - Removed
       .addItem('Rebuild Dashboard From Form Responses', 'rebuildDashboardMenu') // Wrapper - CAUTION: Check if this logic is still valid/needed without a Form Responses sheet being the primary input
       .addItem('Setup/Update All Triggers', 'setupAllTriggersMenu') // Wrapper

--- a/MenuActions.js
+++ b/MenuActions.js
@@ -138,6 +138,36 @@ function setupAllExpenseSheetsMenu() {
 
 
 // --- Maintenance Wrappers ---
+
+function cleanupLegacyCacheMenu() {
+  const ui = SpreadsheetApp.getUi();
+  if (!isCurrentUserAdmin()) {
+    ui.alert('You must be an admin to perform this action.');
+    return;
+  }
+  const response = ui.prompt(
+    'Confirm Legacy Cache Cleanup',
+    'This will remove old, generic cache keys. This is a one-time operation. Type "CLEANUP" to confirm.',
+    ui.ButtonSet.OK_CANCEL
+  );
+
+  if (response.getSelectedButton() == ui.Button.OK && response.getResponseText() == 'CLEANUP') {
+    try {
+      const result = cleanupLegacyCacheKeys();
+      if (result.success) {
+        ui.alert('Success', result.message, ui.ButtonSet.OK);
+      } else {
+        ui.alert('Error', result.message, ui.ButtonSet.OK);
+      }
+    } catch (e) {
+      Logger.log(`Error cleaning up legacy cache from menu: ${e}`);
+      ui.alert(`An error occurred: ${e.message}`);
+    }
+  } else {
+    ui.alert('Cleanup cancelled.');
+  }
+}
+
 function setupAllTriggersMenu() {
     const ui = SpreadsheetApp.getUi();
     try {

--- a/WebApp.js
+++ b/WebApp.js
@@ -2014,7 +2014,7 @@ function saveBudgetCategoriesData(categories) {
     }
 
     // Clear cache to force refresh
-    resetExpenseDataCache();
+    resetExpenseDataCache(householdId);
 
     return {
       success: true,


### PR DESCRIPTION
This commit fixes an issue where the expense tracker data was not updating dynamically after a new expense was submitted. The root cause was an incorrect cache invalidation mechanism.

This commit introduces the following changes:
- Updates `resetExpenseDataCache` to accept a `householdId` and removes the correct, specific cache key.
- Updates all calls to this function to pass the necessary `householdId`.
- Addresses feedback from code review:
  - Creates a private helper function `_getExpenseCacheKey` to centralize cache key generation logic and improve maintainability.
  - Updates JSDoc for `resetExpenseDataCache` to accurately reflect that `householdId` can be a string or null.
  - Creates a separate, one-time admin function `cleanupLegacyCacheKeys` to purge old, generic cache keys, and adds a corresponding menu item. This is more efficient and safer than cleaning up on every cache reset.