### PR TITLE
feat(css): Reduce household banner footprint

### DIFF
--- a/Stylesheet.html
+++ b/Stylesheet.html
@@ -694,10 +694,10 @@ body {
 }
 
 /* Household styles for both ActivityTracker and Dashboard */
-.household-info { background-color: #E8F5E9; border: 1px solid #C8E6C9; border-radius: 8px; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
-.household-name { font-size: 18px; font-weight: 500; color: #2E7D32; display: flex; align-items: center; gap: 8px; }
-.household-icon { font-size: 20px; }
-.household-members { color: #5f6368; font-size: 14px; }
+.household-info { background-color: #E8F5E9; border: 1px solid #C8E6C9; border-radius: 6px; padding: 8px 12px; display: flex; flex-direction: column; gap: 4px; }
+.household-name { font-size: 16px; font-weight: 500; color: #2E7D32; display: flex; align-items: center; gap: 6px; }
+.household-icon { font-size: 18px; }
+.household-members { color: #5f6368; font-size: 12px; }
 
 .no-household-error { background-color: #FFEBEE; border: 1px solid #FFCDD2; border-radius: 8px; padding: 24px; margin: 0 auto 20px auto; max-width: 600px; text-align: center; }
 .error-icon { font-size: 36px; margin-bottom: 16px; color: #C62828; }


### PR DESCRIPTION
This commit reduces the size of the household information banner that appears on the Dashboard, Activity Tracker, and Expense Tracker pages.

I made the following changes to `Stylesheet.html` to create a more compact banner:
- Decreased padding and gap in the `.household-info` container.
- Reduced font sizes for `.household-name`, `.household-icon`, and `.household-members`.
- Adjusted gaps and border-radius for a more compact appearance.

These changes address your feedback that the banner was taking up too much space and ensure a consistent, smaller footprint across all relevant pages.