### PR TITLE
Fix: Reduce horizontal padding of navigation tabs

### DIFF
--- a/Stylesheet.html
+++ b/Stylesheet.html
@@ -126,7 +126,7 @@ body {
 }
 
 .nav-link {
-  padding: 16px 24px;
+  padding: 16px 16px;
   color: var(--text-secondary);
   text-decoration: none;
   font-weight: 500;


### PR DESCRIPTION
The navigation tabs were wrapping to a second row on smaller screens. This change reduces the left and right padding of the `.nav-link` element from 24px to 16px.

This makes the tabs narrower, allowing them to fit on a single row on a wider range of screen sizes without affecting the vertical padding or font size.